### PR TITLE
Fix URL, Add URLDATE and Add To ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
-# SDIPUTS
-Style Dictionaries for Information Presentations in UTS (UTS Harvard Style reference and in-text citations)
+Harvard UTS Referencing .bst file (SDIPUTS)
+==================================
+
+# Introduction 
+Style Dictionaries for Information Presentations in UTS (_UTS Harvard Referencing Style_ reference and in-text citations).
+
+This style file aims to implement the _UTS Harvard Referencing Style_ in BibTeX
+
+The official style guide for _UTS Harvard Referencing Style_ is available from the UTS Library:
+http://www.lib.uts.edu.au/help/referencing/harvard-uts-referencing-guide
+
+# Instructions
+## Download
+The latest version of the .bst file can be downloaded from this GitHub repo.
+
+The .bst file should be placed in the same directory as your .tex file with the below preamble.
+
+## Using in a LaTeX document
+### Preamble 
+In the preamble of your .tex document, include the following:
+
+```
+\usepackage[british]{datetime2} % For urldate formatting
+\usepackage{natbib}
+\bibliographystyle{uts} % Import Harvard UTS style
+\setcitestyle{aysep={}} % Remove comma separation between author and year for in-text citations
+```
+
+### In-Text Citation
+In-Text citations can be performed with parenthesis using '\citep{bibtexkey}' or without using '\citet{bibtexkey}'.
+
+#### `\citep`
+```
+Custom software development is less profitable than developing shrinkwrap software \citep{spolsky_2005}.
+```
+
+Results in:
+```
+Custom software development is less profitable than developing shrinkwrap software (Spolsky 2005).
+```
+
+#### `\citet`
+```
+\citet{spolsky_2005} said that custom software development is less profitable than developing shrinkwrap software.
+```
+
+Results in:
+```
+Spolsky (2005) said that custom software development is less profitable than developing shrinkwrap software
+```
+
+### Referencing
+In your .bib BibTeX file, all standard BiBTeX reference types should be supported -- but most effort has gone into the following reference types.
+
+* journal articles (with `article`)
+* online resources (with `misc`)
+
+Below are examples of each reference type:
+
+#### Journal articles
+Google scholar can automatically export journal articles in BibTeX format which is very useful!
+
+```
+@article{dijkstra1959note,
+  title={A note on two problems in connexion with graphs},
+  author={Dijkstra, Edsger W},
+  journal={Numerische mathematik},
+  volume={1},
+  number={1},
+  pages={269--271},
+  year={1959},
+  publisher={Springer}
+}
+```
+
+#### Online resources
+The 'urldate' tag is used for the last viewed element of the reference.
+
+```
+@misc{spolsky_2005, 
+  title={Set Your Priorities}, 
+  url={https://www.joelonsoftware.com/2005/10/12/set-your-priorities/}, 
+  urldate = {2018-08-23},
+  journal={Joel on Software}, 
+  author={Spolsky, Joel}, 
+  year={2005}
+}
+```

--- a/uts.bst
+++ b/uts.bst
@@ -73,6 +73,7 @@ ENTRY
     series
     title
     type
+    urldate
     url
     volume
     year
@@ -346,7 +347,7 @@ MACRO {ieeese} {"IEEE Transactions on Software Engineering"}
 MACRO {ieeetc} {"IEEE Transactions on Computers"}
 
 MACRO {ieeetcad}
- {"IEEE Transactions on Computer-Aided Design of Integrated Circuits"}
+{"IEEE Transactions on Computer-Aided Design of Integrated Circuits"}
 
 MACRO {ipl} {"Information Processing Letters"}
 
@@ -407,6 +408,7 @@ FUNCTION {bibinfo.warn}
     }
   if$
 }
+
 FUNCTION {format.url}
 {
   url
@@ -416,8 +418,16 @@ FUNCTION {format.url}
   if$
 }
 
-INTEGERS { nameptr namesleft numnames }
+FUNCTION {format.urldate}
+{ 
+  urldate 
+  duplicate$ empty$
+    { pop$ "" }
+    { "viewed \DTMdate{" swap$ * "}" * }
+  if$
+}
 
+INTEGERS { nameptr namesleft numnames }
 
 STRINGS  { bibinfo}
 
@@ -1037,6 +1047,7 @@ FUNCTION {article}
     { format.journal.pages }
     { format.journal.eid }
   if$
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1068,6 +1079,7 @@ FUNCTION {book}
       format.book.crossref output.nonnull
     }
   if$
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1082,6 +1094,7 @@ FUNCTION {booklet}
   end.quote.title
   howpublished "howpublished" bibinfo.check output
   address "address" bibinfo.check output
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1117,6 +1130,7 @@ FUNCTION {inbook}
     }
   if$
   format.pages "pages" output.check
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1143,6 +1157,7 @@ FUNCTION {incollection}
     }
   if$
   format.pages "pages" output.check
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1170,6 +1185,7 @@ FUNCTION {inproceedings}
     }
   if$
   format.pages "pages" output.check
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1185,6 +1201,7 @@ FUNCTION {manual}
   organization "organization" bibinfo.check output
   address "address" bibinfo.check output
   format.edition output
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1201,6 +1218,7 @@ FUNCTION {mastersthesis}
   bbl.mthesis format.thesis.type output.nonnull
   school "school" bibinfo.warn output
   address "address" bibinfo.check output
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1215,6 +1233,7 @@ FUNCTION {misc}
   format.title output
   end.quote.title
   howpublished "howpublished" bibinfo.check output
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1230,6 +1249,7 @@ FUNCTION {phdthesis}
   bbl.phdthesis format.thesis.type output.nonnull
   school "school" bibinfo.warn output
   address "address" bibinfo.check output
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1250,6 +1270,7 @@ FUNCTION {proceedings}
       format.publisher.address output
     }
   if$
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1267,6 +1288,7 @@ FUNCTION {techreport}
   format.tr.number output.nonnull
   institution "institution" bibinfo.warn output
   address "address" bibinfo.check output
+  format.urldate output
   format.url output
   format.note output
   fin.entry
@@ -1280,6 +1302,7 @@ FUNCTION {unpublished}
   date.block
   format.title "title" output.check
   end.quote.title
+  format.urldate output
   format.url output
   format.note "note" output.check
   fin.entry
@@ -1575,9 +1598,9 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\url}[1]{\texttt{#1}}"
   write$ newline$
-  "\providecommand{\urlprefix}{< }"
+  "\providecommand{\urlprefix}{\textless}"
   write$ newline$
-  "\providecommand{\urlsuffix}{> }"
+  "\providecommand{\urlsuffix}{\textgreater}"
   write$ newline$
 }
 EXECUTE {begin.bib}


### PR DESCRIPTION
Primary change is adding URLDATE support:
Ensured < and > prefix/suffix are formatted correctly in URLs.

Also added urldate tag for last accessed "viewed " element as explained in http://www.lib.uts.edu.au/help/referencing/harvard-uts-referencing-guide/website-and-social-media

The chosen tag (urldate) and it's format (yyyy-mm-dd) was chosen for compatibility with biblatex.

Unfortunately this has necessitated the use of a macro from the datetime2 package in the .bst file. Another alternative is removing this and requiring users to preformat the date or use the macro in their .bib file.